### PR TITLE
Add supported features to device client

### DIFF
--- a/letpot/deviceclient.py
+++ b/letpot/deviceclient.py
@@ -13,7 +13,7 @@ import aiomqtt
 
 from letpot.converters import CONVERTERS, LetPotDeviceConverter
 from letpot.exceptions import LetPotAuthenticationException, LetPotException
-from letpot.models import AuthenticationInfo, LetPotDeviceStatus
+from letpot.models import AuthenticationInfo, DeviceFeature, LetPotDeviceStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,6 +44,7 @@ class LetPotDeviceClient:
     _email: str
     _device_serial: str
     device_type: str
+    device_features: DeviceFeature = DeviceFeature(0)
     device_model_name: str | None = None
     device_model_code: str | None = None
 
@@ -61,6 +62,7 @@ class LetPotDeviceClient:
         for converter in CONVERTERS:
             if converter.supports_type(device_type):
                 self._converter = converter(device_type)
+                self.device_features = self._converter.supported_features()
                 device_model = self._converter.get_device_model()
                 if device_model is not None:
                     self.device_model_name = device_model[0]

--- a/letpot/models.py
+++ b/letpot/models.py
@@ -2,7 +2,20 @@
 
 from dataclasses import dataclass
 from datetime import time
+from enum import IntFlag, auto
 import time as systime
+
+
+class DeviceFeature(IntFlag):
+    """Features that a LetPot device can support."""
+
+    LIGHT_BRIGHTNESS_LOW_HIGH = auto()
+    LIGHT_BRIGHTNESS_LEVELS = auto()
+    NUTRIENT_BUTTON = auto()
+    PUMP_AUTO = auto()
+    PUMP_STATUS = auto()
+    TEMPERATURE = auto()
+    WATER_LEVEL = auto()
 
 
 @dataclass


### PR DESCRIPTION
Provide a flag for device features to allow easy comparison of features, like: `DeviceFeature.TEMPERATURE in deviceclient.device_features`.