### PR TITLE
Don't require is_remote from device

### DIFF
--- a/letpot/client.py
+++ b/letpot/client.py
@@ -140,7 +140,7 @@ class LetPotClient:
                     name=device["name"],
                     device_type=device["dev_type"],
                     is_online=device["is_online"],
-                    is_remote=device["is_remote"],
+                    is_remote=device.get("is_remote", None),
                 )
             )
 

--- a/letpot/models.py
+++ b/letpot/models.py
@@ -51,7 +51,7 @@ class LetPotDevice:
     name: str
     device_type: str
     is_online: bool
-    is_remote: bool
+    is_remote: bool | None
 
 
 @dataclass


### PR DESCRIPTION
Fixes #15 

Mark `is_remote` as `None` when not present in the devices response, as the API does not report this for all devices.