### PR TITLE
Add LPH64 for LPH-MAX model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+scratchpad.py

--- a/letpot/converters.py
+++ b/letpot/converters.py
@@ -235,7 +235,7 @@ class IGSorAltConverter(LetPotDeviceConverter):
         return []
 
 
-class LPH6xConverter(LetPotDeviceConverter):
+class LPHMaxLowerConverter(LetPotDeviceConverter):
     """Converters and info for device type LPH60, LPH61, LPH62 (Max)."""
 
     @staticmethod
@@ -318,12 +318,12 @@ class LPH6xConverter(LetPotDeviceConverter):
         return [0, 125, 250, 375, 500, 625, 750, 875, 1000]
 
 
-class LPH63Converter(LetPotDeviceConverter):
-    """Converters and info for device type LPH63 (Max)."""
+class LPHMaxHigherConverter(LetPotDeviceConverter):
+    """Converters and info for device type LPH63, LPH64 (Max)."""
 
     @staticmethod
     def supports_type(device_type: str) -> bool:
-        return device_type in ["LPH63"]
+        return device_type in ["LPH63", "LPH64"]
 
     def get_device_model(self) -> tuple[str, str] | None:
         return MODEL_MAX
@@ -399,6 +399,6 @@ class LPH63Converter(LetPotDeviceConverter):
 CONVERTERS: Sequence[type[LetPotDeviceConverter]] = [
     LPHx1Converter,
     IGSorAltConverter,
-    LPH6xConverter,
-    LPH63Converter,
+    LPHMaxLowerConverter,
+    LPHMaxHigherConverter,
 ]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -19,6 +19,7 @@ SUPPORTED_DEVICE_TYPES = [
     "LPH61",
     "LPH62",
     "LPH63",
+    "LPH64",
 ]
 
 


### PR DESCRIPTION
Update device types/serials based on latest decompiled version:
 - LPH64 is another variant for LPH-MAX, matching the existing LPH63 code
 - LPH22/LPH32/LPH42 may be LPH-LITE or also LPH-AIR/LPH-MINI variants, which is currently unclear so skipped