### PR TITLE
Fix ISE0x pump_cycle_mode reading wrong byte

### DIFF
--- a/letpot/converters.py
+++ b/letpot/converters.py
@@ -469,7 +469,7 @@ class ISEConverter(LetPotDeviceConverter):
             pump_cycle_on=data[16] == 1,
             pump_cycle_frequency=256 * data[17] + data[18],
             pump_cycle_duration=256 * data[19] + data[20],
-            pump_cycle_mode=CycleWateringMode(data[10]),
+            pump_cycle_mode=CycleWateringMode(data[21]),
             pump_cycle_workinginterval=256 * data[22] + data[23],
             pump_cycle_restinterval=256 * data[24] + data[25],
             pump_works_latest_reason=data[26],


### PR DESCRIPTION
## Summary

- `pump_cycle_mode` was reading from `data[10]` (part of `pump_manual_duration`) instead of `data[21]` (actual cycle watering mode field)
- Verified with ISE06 device: setting intermittent mode in the app sets `data[21]=1` while `data[10]` remains `0`, causing the library to incorrectly report continuous mode

See test results in #12.

## Test plan

- [x] Set cycle watering to intermittent mode in LetPot app
- [x] Verify `pump_cycle_mode` correctly returns `1` (Intermittent) instead of `0` (Continuous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)